### PR TITLE
Fix encoding issue

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -233,10 +233,10 @@
 
       secretPage = pageTemplate
       secretPage = secretPage.replaceAll("{{PASSWORD_HINT}}", passwordHint)
-      secretPage = secretPage.replaceAll("{{VALUES}}\n", values)
+      secretPage = secretPage.replaceAll("{{VALUES}}", values)
 
-      const dataURI = "data:application/octet-stream;base64," + btoa(secretPage)
-      document.getElementById("target_link").setAttribute("href", dataURI)
+      var blob = new Blob([secretPage], {'type':'text/html'});
+      document.getElementById("target_link").setAttribute("href", window.URL.createObjectURL(blob))
       document.getElementById("target_link").hidden = false
 
       setMessage("✅ Ready for download")


### PR DESCRIPTION
Fixes #7 using a Blob rather than btoa (as btoa() creates a Base64-encoded ASCII string).

Side modification, the `{{VALUES}}\n` substitution does not works on my environnement (even if I take care about Linux vs Windows line feeds...). Feel free to remove this modification if it's not relevant and I just missed up something along the way :-)