### PR TITLE
Execution context warning

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -44,8 +44,8 @@
   const iterations = 1000000 // key derivation (with PBKDF2)
   const keySize = 32 // bytes (derived with PBKDF2, used by AES)
 
-  // Display a warning if the current URI scheme is not HTTPS
-  async function checkScheme() {
+  // Display a warning if the current URL protocol is not HTTPS
+  async function checkURLProtocol() {
     if (window.location.protocol !== 'https:') {
       document.getElementById("danger_text").hidden = false
     }
@@ -60,8 +60,7 @@
   let selectedInputType = ""
 
   async function init() {
-    // Try to detect insecure contexts as soon as possible
-    await checkScheme()
+    await checkURLProtocol()
     await refreshSalt()
     await refreshIV()
     setMessage("Select secret type: message, image, or file")

--- a/creator/secret-template.html
+++ b/creator/secret-template.html
@@ -79,9 +79,9 @@ It uses your browser's cryptograpy APIs to decrypt it, if you know the password.
       document.getElementById("danger_text").hidden = false
     }
   }
+  
   // Display the encryption inputs on the page (invoked during body onload)
   async function loadValues() {
-    // Try to detect insecure contexts as soon as possible
     await checkSecureContext()
     document.getElementById("secret_type").innerHTML = secretType
     document.getElementById("salt").setAttribute("value", saltHex)


### PR DESCRIPTION
Let summarize my proposal #36 in two parts as creator and secret does not meets the same requirements.

A - Concerning the creator: 

**Requires HTTPS at any time**.

> Message: Please host this tool on an HTTPS server (notice that some browsers are not happy with a self-signed certificate).

B - Concerning the secret: 

**Requires a "secure context"** (given by the [isSecureContext ](https://developer.mozilla.org/en-US/docs/Web/API/isSecureContext)property).

> Message: The current browser context is not considered "secure" and portable-secret won't work properly. Please open this secret from your local filesystem (file://) or from an HTTPS server.